### PR TITLE
Minimap Cleanup

### DIFF
--- a/BUI_Events.lua
+++ b/BUI_Events.lua
@@ -125,7 +125,7 @@ local function OnPowerUpdate(eventCode, unitTag, powerIndex, powerType, powerVal
 		end
 	--Group Updates
 	elseif BUI.InGroup and string.sub(unitTag, 0, 5)=="group" then
-		--Health		
+		--Health
 		if (powerType==POWERTYPE_HEALTH) then
 			if BUI.init.Frames then
 				BUI.Player:UpdateAttribute(unitTag, powerType, powerValue, powerMax, powerEffectiveMax)
@@ -176,7 +176,7 @@ local function OnVisualAdded(eventCode, unitTag, unitAttributeVisual, statType, 
 				BUI.Player:UpdateShield(unitTag, (sequenceId==0 and value or 0), maxValue)
 				if sequenceId==0 and value>20000 then BUI.Buffs.BarrierActive=GetGameTimeSeconds()+30 end
 			elseif unitAttributeVisual==ATTRIBUTE_VISUAL_TRAUMA then
-				BUI.Player:UpdateTrauma(unitTag, (sequenceId==0 and value or 0), maxValue)				
+				BUI.Player:UpdateTrauma(unitTag, (sequenceId==0 and value or 0), maxValue)
 			elseif statType==3 and unitAttributeVisual==ATTRIBUTE_VISUAL_DECREASED_STAT and value>1000 then	--unitAttributeVisual==ATTRIBUTE_VISUAL_INCREASED_STAT
 				if BUI.Vars.PlayerFrame then BUI.Frames:AttributeVisual(unitTag,unitAttributeVisual,sequenceId==0) end
 			elseif unitAttributeVisual==ATTRIBUTE_VISUAL_INCREASED_REGEN_POWER or unitAttributeVisual==ATTRIBUTE_VISUAL_DECREASED_REGEN_POWER then
@@ -414,7 +414,7 @@ local function OnWerewolf(eventCode,werewolf)
 			end
 		end
 	end
---	if BUI.Vars.Actions then BUI.CallLater("Actions_PairChanged",3000,BUI.Actions.OnPairChanged) end 
+--	if BUI.Vars.Actions then BUI.CallLater("Actions_PairChanged",3000,BUI.Actions.OnPairChanged) end
 end
 
 --Group Events
@@ -763,7 +763,6 @@ function BUI.RegisterEvents()
 	EVENT_MANAGER:RegisterForEvent("BUI_Event", EVENT_GAMEPAD_PREFERRED_MODE_CHANGED,	function(_,gamepadPreferred)
 		BUI.GamepadMode=gamepadPreferred
 		BUI.Actions.Initialize()
-		BUI.MiniMap.Initialize()
 		BUI.Frames.ZO_Frame_reposition()
 		BUI.Themes_Setup()
 		if BUI.Vars.QuickSlots then BUI.QuickSlots.Update() end

--- a/BUI_MiniMap.lua
+++ b/BUI_MiniMap.lua
@@ -188,7 +188,7 @@ local function ResizePins(resize)
 	end
 end
 
-local function Map_Toggle() --TOKEN419 Unreferenced Function
+local function Map_Toggle() -- Unreferenced Function
 	local _visible=not ZO_WorldMap:IsHidden()
 	ZO_WorldMap:SetHidden(_visible)
 	_G["ZO_WorldMapMapFrame"]:SetHidden(_visible)
@@ -291,12 +291,12 @@ BUI:JoinTables(BUI.Defaults,BUI.MiniMap.Defaults)
 -- Register Functions
 BUI.MiniMap.ZoneChanged = ZoneChanged
 BUI.MiniMap.Update = Update
-BUI.MiniMap.Map_Toggle = Map_Toggle --TOKEN419 Unreferenced Function
+BUI.MiniMap.Map_Toggle = Map_Toggle -- Unreferenced Function
 BUI.MiniMap.ResizePins = ResizePins
 BUI.MiniMap.Restore = Restore
 BUI.MiniMap.Show = Show
 BUI.MiniMap.PinColors = PinColors
-BUI.MiniMap.Initialize = Initialize --TOKEN419 Referenced in BUI_Events
+BUI.MiniMap.Initialize = Initialize
 BUI.MiniMap.UpdateDimensions = UpdateDimensions
 BUI.MiniMap.UpdatePosition = UpdatePosition
 BUI.MiniMap.ZoomUpdate = ZoomUpdate


### PR DESCRIPTION
This removes a check call into minimap from events as well as places some of the variables into the bui.minimap table.

All functions have been localized and are exported publicly via the bui.minimap table.

I moved the bui.minimap table to the bottom of the file, this ensures that nothing above is trying to modify it indirectly.
Also by adding the function definitions at the bottom, we verify that the local functions are properly calling the external functions instead of indirect calls.