### PR TITLE
Dungeon Quest Update to set obj.needDungeonQuest to nil if the player has completed the dungeon quest.

### DIFF
--- a/BUI_Automation.lua
+++ b/BUI_Automation.lua
@@ -374,6 +374,8 @@ local function UndauntedPledges()
 								text=text..((DungeonIndex[id].quest and GetCompletedQuestInfo(DungeonIndex[id].quest) == "" and obj.node.data.isLocked == false) and "|t20:20:/esoui/art/compass/quest_available_icon.dds|t" or "") --/esoui/art/compass/quest_available_icon.dds /esoui/art/icons/poi/poi_dungeon_complete.dds
 								if GetCompletedQuestInfo(DungeonIndex[id].quest) == "" then
 									obj.needDungeonQuest = true
+								else
+									obj.needDungeonQuest = nil
 								end
  							end
 							--Achievment icons


### PR DESCRIPTION
This sets obj.needDungeonQuest to nil if the player has completed the dungeon quest.

Previously it was only being set to true if the player had not completed the quest, but then would never get set to false unless the UI got reloaded, so if the player subsequently used the feature to select all the quests on the next run, it would have also included any they had completed in this play session as well.